### PR TITLE
Removed unneeded bundle declaration causing issues in latest Cocoapods.

### DIFF
--- a/Voltron.podspec
+++ b/Voltron.podspec
@@ -26,9 +26,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes'
-  s.resource_bundles = {
-    'Voltron' => ['Pod/Assets/*.png']
-  }
 
   s.frameworks = 'UIKit'
 end


### PR DESCRIPTION
In Cocoapods 0.36b2 the copy resources script fails when Voltron is used because of a malformed bundle command.  However, upon inspection, Voltron doesn't need a bundle as it doesn't have PNG assets that need to be in the final product.